### PR TITLE
If there is no emoji nor image, hide the toolbar

### DIFF
--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -11,6 +11,7 @@
 				<v-card :outlined="outline" ref="md-editor">
 					<!-- Toolbar's style "transform: translateY(0)" will influence the z-index, so use "z-index: 1" on toolbar-->
 					<v-toolbar
+						v-if="emoji || image"
 						:style="{ position: 'relative', 'z-index': 1 }"
 						height="48px"
 						flat


### PR DESCRIPTION
I thought it is a good thing to hide the toolbar if there is no image nor emoji available, let me know what do you think :) 